### PR TITLE
Rewrite way of getting error classes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,3 +15,4 @@ issues:
       - gochecknoglobals
       - govet
       - errcheck
+      - goconst

--- a/collector_test.go
+++ b/collector_test.go
@@ -54,7 +54,7 @@ func TestCollector_Report(t *testing.T) {
 		t.Errorf("expected a propagated error")
 	}
 
-	if errorWithContext.Error.Class != "github.com/soundcloud/periskop-go.TestCollector_Report" {
+	if errorWithContext.Error.Class != "*errors.errorString" {
 		t.Errorf("incorrect class name, got %s", errorWithContext.Error.Class)
 	}
 
@@ -82,7 +82,7 @@ func TestCollector_ReportWithHTTPContext(t *testing.T) {
 		t.Errorf("expected HTTP method GET")
 	}
 
-	if errorWithContext.Error.Class != "github.com/soundcloud/periskop-go.TestCollector_ReportWithHTTPContext" {
+	if errorWithContext.Error.Class != "*errors.errorString" {
 		t.Errorf("incorrect class name, got %s", errorWithContext.Error.Class)
 	}
 }
@@ -106,7 +106,7 @@ func TestCollector_ReportWithHTTPRequest(t *testing.T) {
 		t.Errorf("expected HTTP method GET")
 	}
 
-	if errorWithContext.Error.Class != "github.com/soundcloud/periskop-go.TestCollector_ReportWithHTTPRequest" {
+	if errorWithContext.Error.Class != "*errors.errorString" {
 		t.Errorf("incorrect class name, got %s", errorWithContext.Error.Class)
 	}
 }

--- a/types.go
+++ b/types.go
@@ -84,10 +84,10 @@ type errorInstance struct {
 	Cause      *errorInstance `json:"cause"`
 }
 
-func newErrorInstance(err error, funcCaller string, stacktrace []string) errorInstance {
+func newErrorInstance(err error, errType string, stacktrace []string) errorInstance {
 	return errorInstance{
 		Message:    err.Error(),
-		Class:      funcCaller,
+		Class:      errType,
 		Stacktrace: stacktrace,
 	}
 }
@@ -98,7 +98,7 @@ func (e *errorWithContext) aggregationKey() string {
 	if len(stacktraceHead) > MaxTraces {
 		stacktraceHead = stacktraceHead[:MaxTraces]
 	}
-	stacktraceHeadHash := hash(strings.Join(stacktraceHead, ""))
+	stacktraceHeadHash := hash(e.Error.Message + strings.Join(stacktraceHead, ""))
 	return fmt.Sprintf("%s@%s", e.Error.Class, stacktraceHeadHash)
 }
 

--- a/types_test.go
+++ b/types_test.go
@@ -7,13 +7,15 @@ import (
 
 var aggregationKeyCases = []struct {
 	expectedAggregationKey string
+	errorMessage           string
 	stacktrace             []string
 }{
-	{"testingError@811c9dc5", []string{""}},
-	{"testingError@8de5e669", []string{"line 0:", "division by zero"}},
-	{"testingError@203345ae", []string{"line 0:", "division by zero", "line 1:", "line 4:", "checkTest()"}},
-	{"testingError@2235876b", []string{"line 0:", "division by zero", "line 1:", "line 5:", "checkTest()"}},
-	{"testingError@2235876b", []string{"line 0:", "division by zero", "line 1:", "line 5:", "checkAnotherTest()"}},
+	{"testingError@af88b146", "error", []string{""}},
+	{"testingError@b8a5702f", "timeout error", []string{"line 0:", "error in testingError"}},
+	{"testingError@b8a5702f", "index error", []string{"line 0:", "error in testingError"}},
+	{"testingError@e1441017", "index error", []string{"line 0:", "index error", "line 1:", "line 4:", "checkTest()"}},
+	{"testingError@df41ce5a", "index error", []string{"line 0:", "index error", "line 1:", "line 5:", "checkTest()"}},
+	{"testingError@df41ce5a", "index error", []string{"line 0:", "index error", "line 1:", "line 5:", "checkFunc()"}},
 }
 
 func newMockErrorWithContext(stacktrace []string) errorWithContext {


### PR DESCRIPTION
- Previous implementation was using the function where the error
was produced which is incorrect. Now we get the type of the error
using `reflect.TypeOf` method.
- Added the error message to hash generation. This allows us to generate
different hashes for errors produced in the same place but with different
messages.