### PR TITLE
Fix race condition in Export method

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: test lint
 
 test:
-	go test -v
+	go test -v -race
 
 lint :
 	golangci-lint run

--- a/collector.go
+++ b/collector.go
@@ -61,10 +61,12 @@ func getStackTrace(err error) []string {
 }
 
 func (c *ErrorCollector) getAggregatedErrors() payload {
-	aggregatedErrors := make([]*aggregatedError, 0)
+	c.mux.RLock()
+	defer c.mux.RUnlock()
+	aggregatedErrors := make([]aggregatedError, 0)
 	c.aggregatedErrors.Range(func(key, value interface{}) bool {
 		aggregatedErr, _ := value.(*aggregatedError)
-		aggregatedErrors = append(aggregatedErrors, aggregatedErr)
+		aggregatedErrors = append(aggregatedErrors, *aggregatedErr)
 		return true
 	})
 	return payload{aggregatedErrors}

--- a/collector.go
+++ b/collector.go
@@ -79,7 +79,6 @@ func (c *ErrorCollector) addError(err error, httpCtx *HTTPContext) {
 	c.mux.Lock()
 	if aggregatedErr, ok := c.aggregatedErrors[aggregationKey]; ok {
 		aggregatedErr.addError(errorWithContext)
-
 	} else {
 		aggregatedErr := newAggregatedError(aggregationKey, SeverityError)
 		aggregatedErr.addError(errorWithContext)

--- a/collector.go
+++ b/collector.go
@@ -77,6 +77,7 @@ func (c *ErrorCollector) addError(err error, httpCtx *HTTPContext) {
 	errorWithContext := newErrorWithContext(errorInstance, SeverityError, httpCtx)
 	aggregationKey := errorWithContext.aggregationKey()
 	c.mux.Lock()
+	defer c.mux.Unlock()
 	if aggregatedErr, ok := c.aggregatedErrors[aggregationKey]; ok {
 		aggregatedErr.addError(errorWithContext)
 	} else {
@@ -84,5 +85,4 @@ func (c *ErrorCollector) addError(err error, httpCtx *HTTPContext) {
 		aggregatedErr.addError(errorWithContext)
 		c.aggregatedErrors[aggregationKey] = &aggregatedErr
 	}
-	c.mux.Unlock()
 }

--- a/collector_test.go
+++ b/collector_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func getAggregateErr(aggregatedErrors map[string]*aggregatedError) *aggregatedError {
+func getFirstAggregatedErr(aggregatedErrors map[string]*aggregatedError) *aggregatedError {
 	for _, value := range aggregatedErrors {
 		return value
 	}
@@ -23,7 +23,7 @@ func TestCollector_addError(t *testing.T) {
 	}
 
 	c.addError(err, nil)
-	if getAggregateErr(c.aggregatedErrors).TotalCount != 2 {
+	if getFirstAggregatedErr(c.aggregatedErrors).TotalCount != 2 {
 		t.Errorf("expected two elements")
 	}
 }
@@ -37,7 +37,7 @@ func TestCollector_Report(t *testing.T) {
 		t.Errorf("expected one element")
 	}
 
-	errorWithContext := getAggregateErr(c.aggregatedErrors).LatestErrors[0]
+	errorWithContext := getFirstAggregatedErr(c.aggregatedErrors).LatestErrors[0]
 	if errorWithContext.Error.Message != err.Error() {
 		t.Errorf("expected a propagated error")
 	}
@@ -65,7 +65,7 @@ func TestCollector_ReportWithHTTPContext(t *testing.T) {
 		t.Errorf("expected one element")
 	}
 
-	errorWithContext := getAggregateErr(c.aggregatedErrors).LatestErrors[0]
+	errorWithContext := getFirstAggregatedErr(c.aggregatedErrors).LatestErrors[0]
 	if errorWithContext.HTTPContext.RequestMethod != "GET" {
 		t.Errorf("expected HTTP method GET")
 	}
@@ -89,7 +89,7 @@ func TestCollector_ReportWithHTTPRequest(t *testing.T) {
 		t.Errorf("expected one element")
 	}
 
-	errorWithContext := getAggregateErr(c.aggregatedErrors).LatestErrors[0]
+	errorWithContext := getFirstAggregatedErr(c.aggregatedErrors).LatestErrors[0]
 	if errorWithContext.HTTPContext.RequestMethod != "GET" {
 		t.Errorf("expected HTTP method GET")
 	}
@@ -104,7 +104,7 @@ func TestCollector_getAggregatedErrors(t *testing.T) {
 	err := errors.New("testing")
 	c.addError(err, nil)
 
-	aggregatedErr := getAggregateErr(c.aggregatedErrors)
+	aggregatedErr := getFirstAggregatedErr(c.aggregatedErrors)
 	payload := c.getAggregatedErrors()
 	if payload.AggregatedErrors[0].AggregationKey != aggregatedErr.AggregationKey {
 		t.Errorf("keys for aggregated errors are different, expected: %s, got: %s",

--- a/collector_test.go
+++ b/collector_test.go
@@ -3,26 +3,14 @@ package periskop
 import (
 	"errors"
 	"net/http"
-	"sync"
 	"testing"
 )
 
-func getAggregateErr(aggregatedErrors sync.Map) *aggregatedError {
-	aggregatedErr := &aggregatedError{}
-	aggregatedErrors.Range(func(key, value interface{}) bool {
-		aggregatedErr, _ = value.(*aggregatedError)
-		return false
-	})
-	return aggregatedErr
-}
-
-func count(aggregatedErrors sync.Map) int {
-	count := 0
-	aggregatedErrors.Range(func(key, value interface{}) bool {
-		count++
-		return true
-	})
-	return count
+func getAggregateErr(aggregatedErrors map[string]*aggregatedError) *aggregatedError {
+	for _, value := range aggregatedErrors {
+		return value
+	}
+	return nil
 }
 
 func TestCollector_addError(t *testing.T) {
@@ -30,7 +18,7 @@ func TestCollector_addError(t *testing.T) {
 	err := errors.New("testing")
 	c.addError(err, nil)
 
-	if count(c.aggregatedErrors) != 1 {
+	if len(c.aggregatedErrors) != 1 {
 		t.Errorf("expected one element")
 	}
 
@@ -45,7 +33,7 @@ func TestCollector_Report(t *testing.T) {
 	err := errors.New("testing")
 	c.Report(err)
 
-	if count(c.aggregatedErrors) != 1 {
+	if len(c.aggregatedErrors) != 1 {
 		t.Errorf("expected one element")
 	}
 
@@ -73,7 +61,7 @@ func TestCollector_ReportWithHTTPContext(t *testing.T) {
 	}
 	c.ReportWithHTTPContext(err, &httpContext)
 
-	if count(c.aggregatedErrors) != 1 {
+	if len(c.aggregatedErrors) != 1 {
 		t.Errorf("expected one element")
 	}
 
@@ -97,7 +85,7 @@ func TestCollector_ReportWithHTTPRequest(t *testing.T) {
 	err = errors.New("testing")
 	c.ReportWithHTTPRequest(err, req)
 
-	if count(c.aggregatedErrors) != 1 {
+	if len(c.aggregatedErrors) != 1 {
 		t.Errorf("expected one element")
 	}
 

--- a/exporter.go
+++ b/exporter.go
@@ -18,10 +18,8 @@ func NewErrorExporter(collector *ErrorCollector) ErrorExporter {
 
 // Export exports all collected errors in json format
 func (e *ErrorExporter) Export() (string, error) {
-	e.collector.mux.RLock()
 	payload := e.collector.getAggregatedErrors()
 	res, err := json.Marshal(payload)
-	e.collector.mux.RUnlock()
 	if err != nil {
 		return "", err
 	}

--- a/exporter.go
+++ b/exporter.go
@@ -18,7 +18,10 @@ func NewErrorExporter(collector *ErrorCollector) ErrorExporter {
 
 // Export exports all collected errors in json format
 func (e *ErrorExporter) Export() (string, error) {
-	res, err := json.Marshal(e.collector.getAggregatedErrors())
+	e.collector.mux.RLock()
+	payload := e.collector.getAggregatedErrors()
+	res, err := json.Marshal(payload)
+	e.collector.mux.RUnlock()
 	if err != nil {
 		return "", err
 	}

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -84,7 +84,7 @@ func TestExporter_Export(t *testing.T) {
 		  }
 		]
 	  }`
-	c.aggregatedErrors.Store("test", &errorAggregate)
+	c.aggregatedErrors["test"] = &errorAggregate
 	e := NewErrorExporter(&c)
 	data, err := e.Export()
 	if err != nil {

--- a/integration_test.go
+++ b/integration_test.go
@@ -43,7 +43,7 @@ func TestHandler(t *testing.T) {
 	}
 	p := parseJSON(rr.Body.String())
 	if p.AggregatedErrors[0].TotalCount != 2 {
-		t.Errorf("no exceptions collected: %s", rr.Body.String())
+		t.Errorf("wrong number of exceptions collected: %s", rr.Body.String())
 	}
 }
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -52,6 +52,7 @@ func TestConcurrency(t *testing.T) {
 	const maxIterations = 20
 
 	c := NewErrorCollector()
+	e := NewErrorExporter(&c)
 	var wg sync.WaitGroup
 	wg.Add(maxGoRoutines)
 	for i := 0; i < maxGoRoutines; i++ {
@@ -62,10 +63,10 @@ func TestConcurrency(t *testing.T) {
 				c.Report(errFunc())
 			}
 		}()
+		e.Export()
 	}
 	wg.Wait()
 
-	e := NewErrorExporter(&c)
 	s, _ := e.Export()
 	p := parseJSON(s)
 	if p.AggregatedErrors[0].TotalCount != maxGoRoutines*maxIterations {

--- a/types.go
+++ b/types.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"hash/fnv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -30,7 +29,6 @@ type aggregatedError struct {
 	TotalCount     int                `json:"total_count"`
 	Severity       Severity           `json:"severity"`
 	LatestErrors   []errorWithContext `json:"latest_errors"`
-	mux            sync.Mutex
 }
 
 func newAggregatedError(aggregationKey string, severity Severity) aggregatedError {
@@ -42,14 +40,12 @@ func newAggregatedError(aggregationKey string, severity Severity) aggregatedErro
 }
 
 func (e *aggregatedError) addError(errWithContext errorWithContext) {
-	e.mux.Lock()
 	if len(e.LatestErrors) >= MaxErrors {
 		// dequeue
 		e.LatestErrors = e.LatestErrors[1:]
 	}
 	e.LatestErrors = append(e.LatestErrors, errWithContext)
 	e.TotalCount++
-	e.mux.Unlock()
 }
 
 // HTTPContext holds info of the HTTP context when an error is produced

--- a/types.go
+++ b/types.go
@@ -21,7 +21,7 @@ const (
 )
 
 type payload struct {
-	AggregatedErrors []*aggregatedError `json:"aggregated_errors"`
+	AggregatedErrors []aggregatedError `json:"aggregated_errors"`
 }
 
 type aggregatedError struct {


### PR DESCRIPTION
Previous implementation used a `sync.Map` to protected the map of `aggregatedErrors` and a mutex for locking `addError` in `types.go`. It turns out that caused a race condition when `addError` and `Export()` method from `exporter.go` was called:
```
WARNING: DATA RACE
Write at 0x00c00011e0c8 by goroutine 10:
  github.com/soundcloud/periskop-go.(*aggregatedError).addError()
      /home/marctc/workspace/go/src/github.com/soundcloud/periskop-go/types.go:50 +0x115
  github.com/soundcloud/periskop-go.(*ErrorCollector).addError()
      /home/marctc/workspace/go/src/github.com/soundcloud/periskop-go/collector.go:78 +0x2e3
  github.com/soundcloud/periskop-go.TestConcurrency.func1()
      /home/marctc/workspace/go/src/github.com/soundcloud/periskop-go/collector.go:24 +0x11d

Previous read at 0x00c00011e0c8 by goroutine 8:
...
  encoding/json.Marshal()
      /usr/local/go/src/encoding/json/encode.go:161 +0x73
  github.com/soundcloud/periskop-go.(*ErrorExporter).Export()
      /home/marctc/workspace/go/src/github.com/soundcloud/periskop-go/exporter.go:21 +0x8b
  github.com/soundcloud/periskop-go.TestConcurrency()
      /home/marctc/workspace/go/src/github.com/soundcloud/periskop-go/integration_test.go:66 +0x186
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199

Goroutine 10 (running) created at:
  github.com/soundcloud/periskop-go.TestConcurrency()
      /home/marctc/workspace/go/src/github.com/soundcloud/periskop-go/integration_test.go:59 +0x178
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199

```

The solution is lock `getAggregatedErrors` method with an `RLock` and not use pointers to copy the slice of `aggregatedErrors` in order to avoid race conditions while marshaling the payload of collected errors. Also, this PR removes the usage of `sync.Map` and just uses a `sync.Mutex` since the lock is used in more places than protecting the map.