### PR TITLE
Add option to specify aggregation key when reporting errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,18 +61,23 @@ func main() {
 
 ### Custom aggregation for reported errors
 
-By default errors are aggregated by their _stack trace_ and _error message_. This might cause that errors that apparently are the same are treated as different in Periskop.
+By default errors are aggregated by their _stack trace_ and _error message_. This might cause that errors that are the same (but with different message) are treated as different in Periskop:
+
+```
+*url.Error@efdca928 -> Get "http://example": dial tcp 10.10.10.1:10100: i/o timeout
+*url.Error@824c748e -> Get "http://example": dial tcp 10.10.10.2:10100: i/o timeout
+```
 
 To avoid that, you can manually group errors specifying the error key that you want to use:
 
 ```go
 func main() {
 	c := periskop.NewErrorCollector()
-
-	c.Report(faultyJSONParser(), "json-parser-error")
+	req, err := http.NewRequest("GET", "http://example.com", nil)
+	c.ReportWithHTTPRequest(err, req, "example-request-error")
 }
 ```
-__Note:__ With this method you are also aggregating by _error class_ which means that for the previous example the aggregation key is `*json.SyntaxError@json-parser-error`.
+__Note:__ With this method you are also aggregating by _error class_ which means that for the previous example the aggregation key is `*url.Error@example-request-error`.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ func main() {
 	c.Report(faultyJSONParser(), "json-parser-error")
 }
 ```
+__Note:__ With this method you are also aggregating by _error class_ which means that for the previous example the aggregation key is `*json.SyntaxError@json-parser-error`.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,20 @@ func main() {
 }
 ```
 
+### Custom aggregation for reported errors
+
+By default errors are aggregated by their _stack trace_ and _error message_. This might cause that errors that apparently are the same are treated as different in Periskop.
+
+To avoid that, you can manually group errors specifying the error key that you want to use:
+
+```go
+func main() {
+	c := periskop.NewErrorCollector()
+
+	c.Report(faultyJSONParser(), "json-parser-error")
+}
+```
+
 ## Contributing
 
 Please see [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/collector.go
+++ b/collector.go
@@ -1,6 +1,7 @@
 package periskop
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -88,9 +89,11 @@ func (c *ErrorCollector) getAggregatedErrors() payload {
 	return payload{aggregatedErrors}
 }
 
+// getAggregationKey get the aggregation key of the error
 func getAggregationKey(errorWithContext errorWithContext, errKey ...string) string {
 	if len(errKey) > 0 {
-		return errKey[0]
+		// aggregate also by error type
+		return fmt.Sprintf("%s@%s", errorWithContext.Error.Class, errKey[0])
 	}
 	return errorWithContext.aggregationKey()
 }

--- a/collector.go
+++ b/collector.go
@@ -90,6 +90,7 @@ func (c *ErrorCollector) getAggregatedErrors() payload {
 }
 
 // getAggregationKey gets the aggregation key of the error
+// Specifying 'errKey' you bypass the default aggregation method
 func getAggregationKey(errorWithContext errorWithContext, errKey ...string) string {
 	if len(errKey) > 0 {
 		// aggregate also by error type

--- a/collector.go
+++ b/collector.go
@@ -89,7 +89,7 @@ func (c *ErrorCollector) getAggregatedErrors() payload {
 	return payload{aggregatedErrors}
 }
 
-// getAggregationKey get the aggregation key of the error
+// getAggregationKey gets the aggregation key of the error
 func getAggregationKey(errorWithContext errorWithContext, errKey ...string) string {
 	if len(errKey) > 0 {
 		// aggregate also by error type

--- a/collector.go
+++ b/collector.go
@@ -25,23 +25,23 @@ func NewErrorCollector() ErrorCollector {
 }
 
 // Report adds an error to map of aggregated errors
-func (c *ErrorCollector) Report(err error) {
-	c.addError(err, nil)
+func (c *ErrorCollector) Report(err error, errKey ...string) {
+	c.addError(err, nil, errKey...)
 }
 
 // ReportWithHTTPContext adds an error (with HTTPContext) to map of aggregated errors
-func (c *ErrorCollector) ReportWithHTTPContext(err error, httpCtx *HTTPContext) {
-	c.addError(err, httpCtx)
+func (c *ErrorCollector) ReportWithHTTPContext(err error, httpCtx *HTTPContext, errKey ...string) {
+	c.addError(err, httpCtx, errKey...)
 }
 
 // ReportWithHTTPRequest adds and error (with HTTPContext from http.Request) to map of aggregated errors
-func (c *ErrorCollector) ReportWithHTTPRequest(err error, r *http.Request) {
+func (c *ErrorCollector) ReportWithHTTPRequest(err error, r *http.Request, errKey ...string) {
 	c.addError(err, &HTTPContext{
 		RequestMethod:  r.Method,
 		RequestURL:     r.URL.String(),
 		RequestHeaders: getAllHeaders(r.Header),
 		RequestBody:    getBody(r.Body),
-	})
+	}, errKey...)
 }
 
 // getBody reads io.Reader request body and returns either body converted to a string or a nil
@@ -88,10 +88,17 @@ func (c *ErrorCollector) getAggregatedErrors() payload {
 	return payload{aggregatedErrors}
 }
 
-func (c *ErrorCollector) addError(err error, httpCtx *HTTPContext) {
+func getAggregationKey(errorWithContext errorWithContext, errKey ...string) string {
+	if len(errKey) > 0 {
+		return errKey[0]
+	}
+	return errorWithContext.aggregationKey()
+}
+
+func (c *ErrorCollector) addError(err error, httpCtx *HTTPContext, errKey ...string) {
 	errorInstance := newErrorInstance(err, reflect.TypeOf(err).String(), getStackTrace(err))
 	errorWithContext := newErrorWithContext(errorInstance, SeverityError, httpCtx)
-	aggregationKey := errorWithContext.aggregationKey()
+	aggregationKey := getAggregationKey(errorWithContext, errKey...)
 	c.mux.Lock()
 	defer c.mux.Unlock()
 	if aggregatedErr, ok := c.aggregatedErrors[aggregationKey]; ok {

--- a/collector_test.go
+++ b/collector_test.go
@@ -55,6 +55,7 @@ func TestCollector_Report_errKey(t *testing.T) {
 	c := NewErrorCollector()
 	err := errors.New("testing")
 	errKey := "grouped-err"
+	errClass := "*errors.errorString"
 	c.Report(err, errKey)
 
 	if len(c.aggregatedErrors) != 1 {
@@ -66,11 +67,11 @@ func TestCollector_Report_errKey(t *testing.T) {
 		t.Errorf("expected a propagated error")
 	}
 
-	if aggregatedErr.AggregationKey != errKey {
+	if aggregatedErr.AggregationKey != errClass+"@"+errKey {
 		t.Errorf("expected an overwritten key")
 	}
 
-	if errorWithContext.Error.Class != "*errors.errorString" {
+	if errorWithContext.Error.Class != errClass {
 		t.Errorf("incorrect class name, got %s", errorWithContext.Error.Class)
 	}
 

--- a/collector_test.go
+++ b/collector_test.go
@@ -51,6 +51,34 @@ func TestCollector_Report(t *testing.T) {
 	}
 }
 
+func TestCollector_Report_errKey(t *testing.T) {
+	c := NewErrorCollector()
+	err := errors.New("testing")
+	errKey := "grouped-err"
+	c.Report(err, errKey)
+
+	if len(c.aggregatedErrors) != 1 {
+		t.Errorf("expected one element")
+	}
+	aggregatedErr := getFirstAggregatedErr(c.aggregatedErrors)
+	errorWithContext := aggregatedErr.LatestErrors[0]
+	if errorWithContext.Error.Message != err.Error() {
+		t.Errorf("expected a propagated error")
+	}
+
+	if aggregatedErr.AggregationKey != errKey {
+		t.Errorf("expected an overwritten key")
+	}
+
+	if errorWithContext.Error.Class != "*errors.errorString" {
+		t.Errorf("incorrect class name, got %s", errorWithContext.Error.Class)
+	}
+
+	if len(errorWithContext.Error.Stacktrace) == 0 {
+		t.Errorf("expected a collected stack trace")
+	}
+}
+
 func TestCollector_ReportWithHTTPContext(t *testing.T) {
 	c := NewErrorCollector()
 	body := "some body"


### PR DESCRIPTION
Current implementation it's causing that a lot of errors which apparently should be the same, are treated as different as we use the error message as part of the aggregation key. This PR adds the ability to specify manually how do you want group reported errors.

This an example how it looks now when you groups `*url.Error` messages:

![Screenshot_2020-06-12 Periskop](https://user-images.githubusercontent.com/280193/84517154-23f9c280-accf-11ea-8d83-df09f2ea042b.png)

Related to: https://github.com/soundcloud/periskop/issues/127