### PR TITLE
Add createdAt to aggregatedError

### DIFF
--- a/exporter_test.go
+++ b/exporter_test.go
@@ -52,7 +52,7 @@ func TestExporter_Export(t *testing.T) {
 		TotalCount:     1,
 		Severity:       SeverityError,
 		LatestErrors:   []errorWithContext{errWithContext},
-		Timestamp:      time.Date(2020, 2, 17, 22, 42, 45, 0, time.UTC),
+		CreatedAt:      time.Date(2020, 2, 17, 22, 42, 45, 0, time.UTC),
 	}
 	var expected = `{
 		"aggregated_errors":[
@@ -60,7 +60,7 @@ func TestExporter_Export(t *testing.T) {
 			"aggregation_key":"test",
 			"total_count":1,
 			"severity":"error",
-			"timestamp":"2020-02-17T22:42:45Z",
+			"created_at":"2020-02-17T22:42:45Z",
 			"latest_errors":[
 			  {
 				"error":{

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -52,6 +52,7 @@ func TestExporter_Export(t *testing.T) {
 		TotalCount:     1,
 		Severity:       SeverityError,
 		LatestErrors:   []errorWithContext{errWithContext},
+		Timestamp:      time.Date(2020, 2, 17, 22, 42, 45, 0, time.UTC),
 	}
 	var expected = `{
 		"aggregated_errors":[
@@ -59,6 +60,7 @@ func TestExporter_Export(t *testing.T) {
 			"aggregation_key":"test",
 			"total_count":1,
 			"severity":"error",
+			"timestamp":"2020-02-17T22:42:45Z",
 			"latest_errors":[
 			  {
 				"error":{

--- a/types.go
+++ b/types.go
@@ -29,6 +29,7 @@ type aggregatedError struct {
 	TotalCount     int                `json:"total_count"`
 	Severity       Severity           `json:"severity"`
 	LatestErrors   []errorWithContext `json:"latest_errors"`
+	Timestamp      time.Time          `json:"timestamp"`
 }
 
 func newAggregatedError(aggregationKey string, severity Severity) aggregatedError {
@@ -36,6 +37,7 @@ func newAggregatedError(aggregationKey string, severity Severity) aggregatedErro
 		AggregationKey: aggregationKey,
 		TotalCount:     0,
 		Severity:       severity,
+		Timestamp:      time.Now().UTC(),
 	}
 }
 

--- a/types.go
+++ b/types.go
@@ -29,7 +29,7 @@ type aggregatedError struct {
 	TotalCount     int                `json:"total_count"`
 	Severity       Severity           `json:"severity"`
 	LatestErrors   []errorWithContext `json:"latest_errors"`
-	Timestamp      time.Time          `json:"timestamp"`
+	CreatedAt      time.Time          `json:"created_at"`
 }
 
 func newAggregatedError(aggregationKey string, severity Severity) aggregatedError {
@@ -37,7 +37,7 @@ func newAggregatedError(aggregationKey string, severity Severity) aggregatedErro
 		AggregationKey: aggregationKey,
 		TotalCount:     0,
 		Severity:       severity,
-		Timestamp:      time.Now().UTC(),
+		CreatedAt:      time.Now().UTC(),
 	}
 }
 


### PR DESCRIPTION
Add `CreatedAt` field to `aggregatedError` in order to track when an error is seen for the first time