### PR TITLE
Add method to create custom reported errors with context

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -66,7 +66,7 @@ func (c *ErrorCollector) ReportWithHTTPRequestAndSeverity(err error, severity Se
 }
 
 // ReportErrorWithContext adds a manually generated errorWithContext with an specific to map of aggregated errors
-func (c *ErrorCollector) ReportErrorWithContext(errWithContext errorWithContext, severity Severity, errKey ...string) {
+func (c *ErrorCollector) ReportErrorWithContext(errWithContext ErrorWithContext, severity Severity, errKey ...string) {
 	c.addErrorWithContext(errWithContext, severity, errKey...)
 }
 
@@ -116,7 +116,7 @@ func (c *ErrorCollector) getAggregatedErrors() payload {
 
 // getAggregationKey gets the aggregation key of the error
 // Specifying 'errKey' you bypass the default aggregation method
-func getAggregationKey(errorWithContext errorWithContext, errKey ...string) string {
+func getAggregationKey(errorWithContext ErrorWithContext, errKey ...string) string {
 	if len(errKey) > 0 {
 		// aggregate also by error type
 		return fmt.Sprintf("%s@%s", errorWithContext.Error.Class, errKey[0])
@@ -130,7 +130,7 @@ func (c *ErrorCollector) addError(err error, severity Severity, httpCtx *HTTPCon
 	c.addErrorWithContext(errWithContext, severity, errKey...)
 }
 
-func (c *ErrorCollector) addErrorWithContext(errWithContext errorWithContext, severity Severity, errKey ...string) {
+func (c *ErrorCollector) addErrorWithContext(errWithContext ErrorWithContext, severity Severity, errKey ...string) {
 	aggregationKey := getAggregationKey(errWithContext, errKey...)
 	c.mux.Lock()
 	defer c.mux.Unlock()

--- a/collector_test.go
+++ b/collector_test.go
@@ -248,7 +248,7 @@ func TestCollector_ReportErrorWithContext(t *testing.T) {
 		RequestHeaders: map[string]string{"Cache-Control": "no-cache"},
 		RequestBody:    &body,
 	}
-	errorInstance := NewManualErrorInstance("testing", "manual_error", []string{"line 0:", "error in testingError"})
+	errorInstance := NewCustomErrorInstance("testing", "manual_error", []string{"line 0:", "error in testingError"})
 	errorWithContext := NewErrorWithContext(errorInstance, SeverityError, &httpContext)
 	c.ReportErrorWithContext(errorWithContext, SeverityError)
 

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -31,8 +31,8 @@ func compareJSON(json0, json1 string) (bool, error) {
 func TestExporter_Export(t *testing.T) {
 	c := NewErrorCollector()
 	uuid, _ := uuid.Parse("5d9893c6-51d6-11ea-8aad-f894c260afe5")
-	errWithContext := errorWithContext{
-		Error: errorInstance{
+	errWithContext := ErrorWithContext{
+		Error: ErrorInstance{
 			Class:      errors.New("testing").Error(),
 			Stacktrace: []string{"line 12:", "syntax error"},
 		},
@@ -51,7 +51,7 @@ func TestExporter_Export(t *testing.T) {
 		AggregationKey: "test",
 		TotalCount:     1,
 		Severity:       SeverityError,
-		LatestErrors:   []errorWithContext{errWithContext},
+		LatestErrors:   []ErrorWithContext{errWithContext},
 		CreatedAt:      time.Date(2020, 2, 17, 22, 42, 45, 0, time.UTC),
 	}
 	var expected = `{

--- a/types.go
+++ b/types.go
@@ -28,7 +28,7 @@ type aggregatedError struct {
 	AggregationKey string             `json:"aggregation_key"`
 	TotalCount     int                `json:"total_count"`
 	Severity       Severity           `json:"severity"`
-	LatestErrors   []errorWithContext `json:"latest_errors"`
+	LatestErrors   []ErrorWithContext `json:"latest_errors"`
 	CreatedAt      time.Time          `json:"created_at"`
 }
 
@@ -41,7 +41,7 @@ func newAggregatedError(aggregationKey string, severity Severity) aggregatedErro
 	}
 }
 
-func (e *aggregatedError) addError(errWithContext errorWithContext) {
+func (e *aggregatedError) addError(errWithContext ErrorWithContext) {
 	if len(e.LatestErrors) >= MaxErrors {
 		// dequeue
 		e.LatestErrors = e.LatestErrors[1:]
@@ -58,34 +58,33 @@ type HTTPContext struct {
 	RequestBody    *string           `json:"request_body"`
 }
 
-type errorWithContext struct {
-	Error       errorInstance `json:"error"`
+type ErrorWithContext struct {
+	Error       ErrorInstance `json:"error"`
 	UUID        uuid.UUID     `json:"uuid"`
 	Timestamp   time.Time     `json:"timestamp"`
 	Severity    Severity      `json:"severity"`
 	HTTPContext *HTTPContext  `json:"http_context"`
 }
 
-func NewErrorWithContext(errInstance errorInstance, severity Severity, httpCtx *HTTPContext) errorWithContext {
-	return errorWithContext{
+func NewErrorWithContext(errInstance ErrorInstance, severity Severity, httpCtx *HTTPContext) ErrorWithContext {
+	return ErrorWithContext{
 		Error:       errInstance,
 		UUID:        uuid.New(),
 		Timestamp:   time.Now().UTC(),
 		Severity:    severity,
 		HTTPContext: httpCtx,
 	}
-
 }
 
-type errorInstance struct {
+type ErrorInstance struct {
 	Class      string         `json:"class"`
 	Message    string         `json:"message"`
 	Stacktrace []string       `json:"stacktrace"`
-	Cause      *errorInstance `json:"cause"`
+	Cause      *ErrorInstance `json:"cause"`
 }
 
-func newErrorInstance(err error, errType string, stacktrace []string) errorInstance {
-	return errorInstance{
+func newErrorInstance(err error, errType string, stacktrace []string) ErrorInstance {
+	return ErrorInstance{
 		Message:    err.Error(),
 		Class:      errType,
 		Stacktrace: stacktrace,
@@ -93,8 +92,8 @@ func newErrorInstance(err error, errType string, stacktrace []string) errorInsta
 }
 
 // NewManualErrorInstance allows to manually create an error instance without specifying a Go error
-func NewManualErrorInstance(errMsg string, errType string, stacktrace []string) errorInstance {
-	return errorInstance{
+func NewManualErrorInstance(errMsg string, errType string, stacktrace []string) ErrorInstance {
+	return ErrorInstance{
 		Message:    errMsg,
 		Class:      errType,
 		Stacktrace: stacktrace,
@@ -102,7 +101,7 @@ func NewManualErrorInstance(errMsg string, errType string, stacktrace []string) 
 }
 
 // aggregationKey generates a hash for errorWithContext using the last MaxTraces
-func (e *errorWithContext) aggregationKey() string {
+func (e *ErrorWithContext) aggregationKey() string {
 	stacktraceHead := e.Error.Stacktrace
 	if len(stacktraceHead) > MaxTraces {
 		stacktraceHead = stacktraceHead[:MaxTraces]

--- a/types.go
+++ b/types.go
@@ -91,8 +91,8 @@ func newErrorInstance(err error, errType string, stacktrace []string) ErrorInsta
 	}
 }
 
-// NewManualErrorInstance allows to manually create an error instance without specifying a Go error
-func NewManualErrorInstance(errMsg string, errType string, stacktrace []string) ErrorInstance {
+// NewCustomErrorInstance allows to manually create an error instance without specifying a Go error
+func NewCustomErrorInstance(errMsg string, errType string, stacktrace []string) ErrorInstance {
 	return ErrorInstance{
 		Message:    errMsg,
 		Class:      errType,

--- a/types.go
+++ b/types.go
@@ -91,7 +91,7 @@ func newErrorInstance(err error, errType string, stacktrace []string) ErrorInsta
 	}
 }
 
-// NewCustomErrorInstance allows to manually create an error instance without specifying a Go error
+// NewCustomErrorInstance allows to create a custom error instance without specifying a Go error
 func NewCustomErrorInstance(errMsg string, errType string, stacktrace []string) ErrorInstance {
 	return ErrorInstance{
 		Message:    errMsg,

--- a/types.go
+++ b/types.go
@@ -66,7 +66,7 @@ type errorWithContext struct {
 	HTTPContext *HTTPContext  `json:"http_context"`
 }
 
-func newErrorWithContext(errInstance errorInstance, severity Severity, httpCtx *HTTPContext) errorWithContext {
+func NewErrorWithContext(errInstance errorInstance, severity Severity, httpCtx *HTTPContext) errorWithContext {
 	return errorWithContext{
 		Error:       errInstance,
 		UUID:        uuid.New(),
@@ -74,6 +74,7 @@ func newErrorWithContext(errInstance errorInstance, severity Severity, httpCtx *
 		Severity:    severity,
 		HTTPContext: httpCtx,
 	}
+
 }
 
 type errorInstance struct {
@@ -86,6 +87,15 @@ type errorInstance struct {
 func newErrorInstance(err error, errType string, stacktrace []string) errorInstance {
 	return errorInstance{
 		Message:    err.Error(),
+		Class:      errType,
+		Stacktrace: stacktrace,
+	}
+}
+
+// NewManualErrorInstance allows to manually create an error instance without specifying a Go error
+func NewManualErrorInstance(errMsg string, errType string, stacktrace []string) errorInstance {
+	return errorInstance{
+		Message:    errMsg,
 		Class:      errType,
 		Stacktrace: stacktrace,
 	}

--- a/types_test.go
+++ b/types_test.go
@@ -20,7 +20,7 @@ var aggregationKeyCases = []struct {
 
 func newMockErrorWithContext(stacktrace []string) errorWithContext {
 	errorInstance := newErrorInstance(errors.New("divisin by zero"), "testingError", stacktrace)
-	return newErrorWithContext(errorInstance, SeverityError, nil)
+	return NewErrorWithContext(errorInstance, SeverityError, nil)
 }
 
 func TestTypes_aggregationKey(t *testing.T) {

--- a/types_test.go
+++ b/types_test.go
@@ -18,7 +18,7 @@ var aggregationKeyCases = []struct {
 	{"testingError@df41ce5a", "index error", []string{"line 0:", "index error", "line 1:", "line 5:", "checkFunc()"}},
 }
 
-func newMockErrorWithContext(stacktrace []string) errorWithContext {
+func newMockErrorWithContext(stacktrace []string) ErrorWithContext {
 	errorInstance := newErrorInstance(errors.New("divisin by zero"), "testingError", stacktrace)
 	return NewErrorWithContext(errorInstance, SeverityError, nil)
 }


### PR DESCRIPTION
This would be specially helpful if someone wants to create custom errors and  report them (adding all needed fields manually). 
Specially for tools like exporters from other services.
