### PR TITLE
Expose target UUID

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/google/uuid"
 	"github.com/soundcloud/periskop-go/errutils"
 )
 
@@ -16,12 +17,14 @@ import (
 type ErrorCollector struct {
 	aggregatedErrors map[string]*aggregatedError
 	mux              sync.RWMutex
+	uuid             uuid.UUID
 }
 
 // NewErrorCollector creates new ErrorCollector
 func NewErrorCollector() ErrorCollector {
 	return ErrorCollector{
 		aggregatedErrors: make(map[string]*aggregatedError),
+		uuid:             uuid.New(),
 	}
 }
 
@@ -111,7 +114,7 @@ func (c *ErrorCollector) getAggregatedErrors() payload {
 	for _, value := range c.aggregatedErrors {
 		aggregatedErrors = append(aggregatedErrors, *value)
 	}
-	return payload{aggregatedErrors}
+	return payload{aggregatedErrors, c.uuid}
 }
 
 // getAggregationKey gets the aggregation key of the error

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -31,6 +31,7 @@ func compareJSON(json0, json1 string) (bool, error) {
 func TestExporter_Export(t *testing.T) {
 	c := NewErrorCollector()
 	uuid, _ := uuid.Parse("5d9893c6-51d6-11ea-8aad-f894c260afe5")
+	c.uuid = uuid
 	errWithContext := ErrorWithContext{
 		Error: ErrorInstance{
 			Class:      errors.New("testing").Error(),
@@ -55,6 +56,7 @@ func TestExporter_Export(t *testing.T) {
 		CreatedAt:      time.Date(2020, 2, 17, 22, 42, 45, 0, time.UTC),
 	}
 	var expected = `{
+		"target_uuid": "5d9893c6-51d6-11ea-8aad-f894c260afe5",
 		"aggregated_errors":[
 		  {
 			"aggregation_key":"test",

--- a/types.go
+++ b/types.go
@@ -22,6 +22,7 @@ const (
 
 type payload struct {
 	AggregatedErrors []aggregatedError `json:"aggregated_errors"`
+	TargetUUID       uuid.UUID         `json:"target_uuid"`
 }
 
 type aggregatedError struct {


### PR DESCRIPTION
  - Exposing a UUID per target collector is necessary to avoid
    collisions which may result in wrong counters.
  - See https://github.com/soundcloud/periskop/issues/169
