### PR TITLE
Convert private vars in ErrorReport to public

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ func main() {
 	c.Report(periskop.ErrorReport{
 		Err:      err,
 		Severity: SeverityWarning,
-		HttpCtx: &periskop.HTTPContext{
+		HTTPCtx: &periskop.HTTPContext{
 			RequestMethod:  "GET",
 			RequestURL:     "http://example.com",
 			RequestHeaders: map[string]string{"Cache-Control": "no-cache"},
@@ -70,7 +70,7 @@ func main() {
 	c.Report(periskop.ErrorReport{
 		Err:         err,
 		Severity:    SeverityWarning,
-		HttpRequest: req,
+		HTTPRequest: req,
 		ErrKey:      "json-parsing",
 	})
 
@@ -100,7 +100,7 @@ func main() {
 	req, err := http.NewRequest("GET", "http://example.com", nil)
 	c.Report(periskop.ErrorReport{
 		Err:         err,
-		HttpRequest: req,
+		HTTPRequest: req,
 		ErrKey:      "example-request-error",
 	})
 }

--- a/README.md
+++ b/README.md
@@ -55,23 +55,23 @@ func main() {
 
 	// With a full error report
 	c.Report(periskop.ErrorReport{
-		err:      err,
-		severity: SeverityWarning,
-		httpCtx: &periskop.HTTPContext{
+		Err:      err,
+		Severity: SeverityWarning,
+		HttpCtx: &periskop.HTTPContext{
 			RequestMethod:  "GET",
 			RequestURL:     "http://example.com",
 			RequestHeaders: map[string]string{"Cache-Control": "no-cache"},
 			RequestBody:    &body,
 		},
-		errKey: "json-parsing", // Overrides the errors aggregation key (see more info below)
+		ErrKey: "json-parsing", // Overrides the errors aggregation key (see more info below)
 	})
 
 	// With a full error report, but with http.Request instead of HTTP context
 	c.Report(periskop.ErrorReport{
-		err:         err,
-		severity:    SeverityWarning,
-		httpRequest: req,
-		errKey:      "json-parsing",
+		Err:         err,
+		Severity:    SeverityWarning,
+		HttpRequest: req,
+		ErrKey:      "json-parsing",
 	})
 
 	// Call the exporter and HTTP handler to expose the
@@ -99,9 +99,9 @@ func main() {
 	c := periskop.NewErrorCollector()
 	req, err := http.NewRequest("GET", "http://example.com", nil)
 	c.Report(periskop.ErrorReport{
-		err:         err,
-		httpRequest: req,
-		errKey:      "example-request-error",
+		Err:         err,
+		HttpRequest: req,
+		ErrKey:      "example-request-error",
 	})
 }
 ```

--- a/collector.go
+++ b/collector.go
@@ -14,11 +14,11 @@ import (
 
 // ErrorReport represents a report of a single error
 type ErrorReport struct {
-	err         error
-	severity    Severity
-	httpRequest *http.Request
-	httpCtx     *HTTPContext
-	errKey      string
+	Err         error
+	Severity    Severity
+	HttpRequest *http.Request
+	HttpCtx     *HTTPContext
+	ErrKey      string
 }
 
 // ErrorCollector collects all the aggregated errors
@@ -38,13 +38,13 @@ func NewErrorCollector() ErrorCollector {
 
 // Report adds an error report to map of aggregated errors. Severity defaults to Error when missing.
 func (c *ErrorCollector) Report(report ErrorReport) {
-	if report.severity == "" {
-		report.severity = SeverityError
+	if report.Severity == "" {
+		report.Severity = SeverityError
 	}
-	if report.httpCtx == nil {
-		report.httpCtx = httpRequestToContext(report.httpRequest)
+	if report.HttpCtx == nil {
+		report.HttpCtx = httpRequestToContext(report.HttpRequest)
 	}
-	c.addError(report.err, report.severity, report.httpCtx, report.errKey)
+	c.addError(report.Err, report.Severity, report.HttpCtx, report.ErrKey)
 }
 
 // ReportError adds an error with severity Error to map of aggregated errors

--- a/collector.go
+++ b/collector.go
@@ -16,8 +16,8 @@ import (
 type ErrorReport struct {
 	Err         error
 	Severity    Severity
-	HttpRequest *http.Request
-	HttpCtx     *HTTPContext
+	HTTPRequest *http.Request
+	HTTPCtx     *HTTPContext
 	ErrKey      string
 }
 
@@ -41,10 +41,10 @@ func (c *ErrorCollector) Report(report ErrorReport) {
 	if report.Severity == "" {
 		report.Severity = SeverityError
 	}
-	if report.HttpCtx == nil {
-		report.HttpCtx = httpRequestToContext(report.HttpRequest)
+	if report.HTTPCtx == nil {
+		report.HTTPCtx = httpRequestToContext(report.HTTPRequest)
 	}
-	c.addError(report.Err, report.Severity, report.HttpCtx, report.ErrKey)
+	c.addError(report.Err, report.Severity, report.HTTPCtx, report.ErrKey)
 }
 
 // ReportError adds an error with severity Error to map of aggregated errors

--- a/collector_test.go
+++ b/collector_test.go
@@ -87,7 +87,7 @@ func TestCollector_Report_errKey(t *testing.T) {
 	err := errors.New("testing")
 	errKey := "grouped-err"
 	errClass := "*errors.errorString"
-	c.Report(ErrorReport{err: err, errKey: errClass + "@" + errKey})
+	c.Report(ErrorReport{Err: err, ErrKey: errClass + "@" + errKey})
 
 	if len(c.aggregatedErrors) != 1 {
 		t.Errorf("expected one element")


### PR DESCRIPTION
This is a fix to #12, where I introduced `periskop.ErrorReport`. It contains variables that need to be set by the client when calling `ErrorCollector.Report()`, however none of those are exposed. This means that a client cannot set any of these variables.
